### PR TITLE
Fix broken link for terraform cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Terraform Cloud Getting Started Guide Example
 
-This is an example Terraform configuration intended for use with the Terraform Cloud Getting Started Guide hosted at https://learn.hashicorp.com/terraform/cloud/tf_cloud_overview
+This is an example Terraform configuration intended for use with the Terraform Cloud Getting Started Guide hosted at https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview


### PR DESCRIPTION
The link for getting started with terraform cloud was broken leading to an old link, showing up 404. This is also there in the [learn.hashicorp.com/terraform/getting-started/remote](https://learn.hashicorp.com/terraform/getting-started/remote). I have updated the link over here.