### PR TITLE
Make DB Table unique for new runs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 }
 
 resource "aws_dynamodb_table" "tfc_example_table" {
-  name = var.db_table_name
+  name = "${var.db_table_name}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
 
   read_capacity  = var.db_read_capacity
   write_capacity = var.db_write_capacity

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ provider "aws" {
   region = var.aws_region
 }
 
+provider "random" {
+  version = "2.2"
+}
+
 resource "random_pet" "table_name" {}
 
 resource "aws_dynamodb_table" "tfc_example_table" {

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,10 @@ provider "aws" {
   region = var.aws_region
 }
 
+resource "random_pet" "table_name" {}
+
 resource "aws_dynamodb_table" "tfc_example_table" {
-  name = "${var.db_table_name}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  name = "${var.db_table_name}-${random_pet.table_name.id}"
 
   read_capacity  = var.db_read_capacity
   write_capacity = var.db_write_capacity

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "aws_region" {
 
 variable "db_table_name" {
   type    = string
-  default = "exampleTable"
+  default = "terraform-learn"
 }
 
 variable "db_read_capacity" {


### PR DESCRIPTION
- Added random_pet to the DB table name so it'll be unique for new runs. Users in the same org will be able to run the guide without destroying the previous table
- Changed `exampleTable` to `terraform-learn` so it's more descriptive