### PR TITLE
fix broken variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   version = "2.33.0"
 
-  region = var.aws_west
+  region = var.aws_region
 }
 
 provider "random" {


### PR DESCRIPTION
This variable "aws_west" is not declared in `variables.tf` and causing an error.