### PR TITLE
updated var key in variables.tf to match change to main.tf made on ef…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "aws_region" {
+variable "aws_west" {
   type    = string
   default = "us-west-1"
 }


### PR DESCRIPTION
In commit efcd12ce41f9b7b223932dd7525d76ff451513bc, the value of aws_region was changed in variables.tf, but the key itself was not altered. In main.tf, though, the key was changed to aws_west, leading to an error on plan. 

I am unsure whether the desired state is for both files to reference aws_region or aws_west, but since the change to main.tf seemed intentional, I've updated the var key in variables.tf to match main.tf. Verified this now plans without error.