### PR TITLE
replace undeclared variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   version = "2.33.0"
 
-  region = var.aws_west
+  region = var.aws_region
 }
 
 provider "random" {


### PR DESCRIPTION
Replacing the value of region for aws provider to var.region, since var.aws_west was not introduced in variables.tf