### PR TITLE
Fix region name variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   version = "2.33.0"
 
-  region = var.aws_west
+  region = var.aws_region
 }
 
 provider "random" {


### PR DESCRIPTION
I don't know if it is by design to have a typo in the region variable name, but this PR is just to fix that so the plan will work on the first try when following https://learn.hashicorp.com/terraform/cloud-getting-started/setup-workspace