### PR TITLE
fixing region var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   version = "2.33.0"
 
-  region = var.aws_west
+  region = var.aws_region
 }
 
 provider "random" {


### PR DESCRIPTION
The region variable is defined as aws_region and was being referenced as aws_west. 