### PR TITLE
Adds explicit variables for aws keys for better error messaging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   version = "2.33.0"
 
   region = var.aws_region
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
 }
 
 provider "random" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,14 @@ variable "aws_region" {
   default = "us-west-1"
 }
 
+variable "aws_access_key_id" {
+  type    = string
+}
+
+variable "aws_secret_access_key" {
+  type    = string
+}
+
 variable "db_table_name" {
   type    = string
   default = "terraform-learn"


### PR DESCRIPTION
When running this for the first time on Terraform Cloud, you'll get an error when you need to add you AWS creds. The documentation around adding key/secret key isn't great and you'd need to know to add the AWS_ACCESS_KEY_ID and AWS_SECRET_KEY env vars.

By adding explicit variables for these keys, we can produce a better error message to unblock future users.