### PR TITLE
Remove tag_user_name variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,4 @@ resource "aws_dynamodb_table" "tfc_example_table" {
     name = "UUID"
     type = "S"
   }
-
-  tags = {
-    user_name = var.tag_user_name
-  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,3 @@ variable "db_write_capacity" {
   type    = number
   default = 1
 }
-
-variable "tag_user_name" {
-  type = string
-}


### PR DESCRIPTION
Removing the variable tag_user_name.

This provides one extra point for the user to potentially mess up, and we're already having them set variables for their AWS creds, so I don't think it provides extra learning for the user.