### PR TITLE
Update Terraform version to v0.14

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,5 @@
 provider "aws" {
-  version = "2.33.0"
-
   region = var.aws_region
-}
-
-provider "random" {
-  version = "2.2"
 }
 
 resource "random_pet" "table_name" {}

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,8 @@ provider "aws" {
   region = var.aws_region
 }
 
+provider "random" {}
+
 resource "random_pet" "table_name" {}
 
 resource "aws_dynamodb_table" "tfc_example_table" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.0.0"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.18"
+    }
+  }
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,13 +1,13 @@
 terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.28.0"
+    }
+    
     random = {
       source  = "hashicorp/random"
       version = "3.0.0"
-    }
-
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 3.18"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,5 @@ terraform {
     }
   }
 
-  version = ">= 0.14.0"
+  required_version = ">= 0.14.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,10 +4,12 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.28.0"
     }
-    
+
     random = {
       source  = "hashicorp/random"
       version = "3.0.0"
     }
   }
+
+  version = ">= 0.14.0"
 }


### PR DESCRIPTION
This upgrades the Terraform configuration to v0.14+ (TFC is currently running at v0.14.7).

This PR addresses issue https://github.com/hashicorp/tfc-guide-example/issues/243.