### PR TITLE
Auto close new PRs and advise the user to fork the example

### DIFF
--- a/.github/workflows/your-fork.yml
+++ b/.github/workflows/your-fork.yml
@@ -1,12 +1,15 @@
 name: Your Fork
 
-on: [pull_request_target]
+on:
+  pull_request_target:
+    types: [opened]
 
 jobs:
-  greeting:
+  close:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/first-interaction@v1
+    - uses: superbrothers/close-pull-request@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        pr-message: 'Hi! If you are following the Terraform Cloud Get Started tutorial, please open the PR against [your personal fork](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-create?in=terraform/cloud-get-started#fork-a-github-repository) of this repository.'
+        # Optional. Post a issue comment just before closing a pull request.
+        comment: "Hi! If you are following the Terraform Cloud Get Started tutorial, please open the PR against [your personal fork](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-create?in=terraform/cloud-get-started#fork-a-github-repository) of this repository. We will automatically closet this PR, but if you intended to edit the example itself please feel free to re-open it."


### PR DESCRIPTION
This PR should add a GitHub action to auto close PRs to this repo when they first open, with a comment advising users to fork the repo. Users should still be able to re-open their PRs without being closed a second time. It uses this [Close Pull Request](https://github.com/marketplace/actions/close-pull-request) action. 

I didn't do very much digging into how to locally test the action, but I think we can just merge it if there aren't obvious issues, and test it in prod. 