### PR TITLE
Add a new condition in workflow

### DIFF
--- a/.github/workflows/your-fork.yml
+++ b/.github/workflows/your-fork.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Optional. Post a issue comment just before closing a pull request.
-        comment: "Hi! If you are following the Terraform Cloud Get Started tutorial, please open the PR against [your personal fork](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-create?in=terraform/cloud-get-started#fork-a-github-repository) of this repository. We will automatically close this PR, but if you intended to edit the example itself please feel free to re-open it."
+        comment: "Hi! If you are following the Terraform Cloud Get Started tutorial, please open the PR against [your personal fork](https://learn.hashicorp.com/tutorials/terraform/cloud-workspace-create?in=terraform/cloud-get-started#fork-a-github-repository) of this repository. We will automatically close this PR, but if you intended to edit the example itself, please add a comment and we will review it as soon as possible."

--- a/.github/workflows/your-fork.yml
+++ b/.github/workflows/your-fork.yml
@@ -8,7 +8,9 @@ jobs:
   close:
     runs-on: ubuntu-latest
     steps:
-    - uses: superbrothers/close-pull-request@v3
+    - name: Automatically close pull requests
+      if: ${{ github.repository.name }} == 'hashicorp/tfc-guide-example'
+      uses: superbrothers/close-pull-request@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Optional. Post a issue comment just before closing a pull request.


### PR DESCRIPTION
The current workflow will automatically close all pull requests. While I understand that it's a desired outcome in the original hashicorp/tfc-guide-example repository, this is not what you'd want in the forked repos. PRs in forked repos will be used to initiate Terraform runs, so they shouldn't be closed automatically.

I've added a condition to the workflow to only close PRs in hashicorp/tfc-guide-example repository.